### PR TITLE
Aggiunto un fix ai link per convertirli a quelli originali.

### DIFF
--- a/main.py
+++ b/main.py
@@ -39,6 +39,9 @@ def get_data(URL):
 	Returns a dictionary containing the infos to
 	generate the url and a list of the episodes
 	'''
+	# fix the link
+	URL = URL.replace("/show/","/#!show/")
+	
 	# Getting info from given URL
 	pattern = "#!show/([0-9]+)/"
 	show_id = re.findall(pattern, URL)[0]


### PR DESCRIPTION
Visto che il nuovo link dove ti reindirizza vvvvid non ti permette di
scaricare con youtube-dl