### PR TITLE
rimozione file .DS_Store

### DIFF
--- a/main.py
+++ b/main.py
@@ -167,12 +167,11 @@ def main():
     if which("ffmpeg") is None:
         # If the user is running the script from Windows or Mac, ffmpeg's build can be inside dependency folder
         if system() in ["Windows", "Darwin"]:
-            try:
-                os.remove(current_dir+"/ffmpeg/.DS_Store")
-            except OSError:
-                pass
+            if os.path.isfile(os.path.join(current_dir, "ffmpeg", ".DS_Store")):
+                os.remove(os.path.join(current_dir, "ffmpeg", ".DS_Store"))
             ffmpeg_dir_files = os.listdir(os.path.join(current_dir, "ffmpeg"))
             ffmpeg_dir_files.remove("readme.md")
+
             # If the directory is ambiguous stop the script
             if len(ffmpeg_dir_files) > 1:
                 print(

--- a/main.py
+++ b/main.py
@@ -167,9 +167,12 @@ def main():
     if which("ffmpeg") is None:
         # If the user is running the script from Windows or Mac, ffmpeg's build can be inside dependency folder
         if system() in ["Windows", "Darwin"]:
+            try:
+                os.remove(current_dir+"/ffmpeg/.DS_Store")
+            except OSError:
+                pass
             ffmpeg_dir_files = os.listdir(os.path.join(current_dir, "ffmpeg"))
             ffmpeg_dir_files.remove("readme.md")
-
             # If the directory is ambiguous stop the script
             if len(ffmpeg_dir_files) > 1:
                 print(


### PR DESCRIPTION
MacOS crea un file '.DS_Store' nella cartella ffmpeg/, il codice rileva la presenza di quel file e si interrompe. Un utente potrebbe non essere a conoscenza di quel file perché l'unico modo di vederlo è dal terminale accedendo a quella cartella e dando il comando 'ls -al' e poi rimuovendolo con 'rm .DS_Store'